### PR TITLE
Added kill history

### DIFF
--- a/lua/autorun/sh_asc_convars.lua
+++ b/lua/autorun/sh_asc_convars.lua
@@ -13,6 +13,7 @@ local min_lose_pct = CreateConVar("ttt_asc_lose_pct_min", "15", {FCVAR_NOTIFY, F
 local show_mstack_messages = CreateConVar("ttt_asc_mstack_messages", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED})
 local show_chat_messages = CreateConVar("ttt_asc_chat_messages", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED})
 local allow_key_respawn = CreateConVar("ttt_asc_allow_key_respawn", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED})
+local use_kill_history = CreateConVar("ttt_asc_use_kill_history", "0", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED})
 
 A_SECOND_CHANCE.CVARS.max_revive_time = max_revive_time:GetFloat()
 A_SECOND_CHANCE.CVARS.min_revive_time = min_revive_time:GetFloat()
@@ -26,6 +27,7 @@ A_SECOND_CHANCE.CVARS.min_lose_pct = min_lose_pct:GetInt()
 A_SECOND_CHANCE.CVARS.show_mstack_messages = show_mstack_messages:GetBool()
 A_SECOND_CHANCE.CVARS.show_chat_messages = show_chat_messages:GetBool()
 A_SECOND_CHANCE.CVARS.allow_key_respawn = allow_key_respawn:GetBool()
+A_SECOND_CHANCE.CVARS.use_kill_history = use_kill_history:GetBool()
 
 if SERVER then
   cvars.AddChangeCallback("ttt_asc_max_revive_time", function(name, old, new)
@@ -76,6 +78,10 @@ if SERVER then
     A_SECOND_CHANCE.CVARS.allow_key_respawn = util.StringToType(new, "bool")
   end, nil)
 
+  cvars.AddChangeCallback("ttt_asc_use_kill_history", function(name, old, new)
+    A_SECOND_CHANCE.CVARS.use_kill_history = util.StringToType(new, "bool")
+  end, nil)
+
   hook.Add("TTTUlxInitCustomCVar", "TTTASCInitCvars", function(name)
     ULib.replicatedWritableCvar("ttt_asc_max_revive_time", "rep_ttt_asc_max_revive_time", GetConVar("ttt_asc_max_revive_time"):GetFloat(), true, false, name)
     ULib.replicatedWritableCvar("ttt_asc_min_revive_time", "rep_ttt_asc_min_revive_time", GetConVar("ttt_asc_min_revive_time"):GetFloat(), true, false, name)
@@ -89,6 +95,7 @@ if SERVER then
     ULib.replicatedWritableCvar("ttt_asc_mstack_messages", "rep_ttt_asc_mstack_messages", GetConVar("ttt_asc_mstack_messages"):GetInt(), true, false, name)
     ULib.replicatedWritableCvar("ttt_asc_chat_messages", "rep_ttt_asc_chat_messages", GetConVar("ttt_asc_chat_messages"):GetInt(), true, false, name)
     ULib.replicatedWritableCvar("ttt_asc_allow_key_respawn", "rep_ttt_asc_allow_key_respawn", GetConVar("ttt_asc_allow_key_respawn"):GetInt(), true, false, name)
+    ULib.replicatedWritableCvar("ttt_asc_use_kill_history", "rep_ttt_asc_use_kill_history", GetConVar("ttt_asc_use_kill_history"):GetInt(), true, false, name)
   end)
 
 end
@@ -97,15 +104,15 @@ if CLIENT then
 
   hook.Add("TTTUlxModifyAddonSettings", "TTTASCModifySettings", function(name)
       local tttrspnl = xlib.makelistlayout{w = 415, h = 300, parent = xgui.null}
-
+      --checkbox: +20, slider: +25
       local tttrsclp = vgui.Create("DCollapsibleCategory", tttrspnl)
-      tttrsclp:SetSize(390, 280)
+      tttrsclp:SetSize(390, 300)
       tttrsclp:SetExpanded(1)
       tttrsclp:SetLabel('Second Chance Settings')
 
       local tttrslst = vgui.Create('DPanelList', tttrsclp)
       tttrslst:SetPos(5, 25)
-      tttrslst:SetSize(390, 280)
+      tttrslst:SetSize(390, 300)
       tttrslst:SetSpacing(5)
       tttrslst:EnableVerticalScrollbar()
 
@@ -146,6 +153,9 @@ if CLIENT then
 
       local checkbox4 = xlib.makecheckbox{label = "ttt_asc_allow_key_respawn (Def. 1)", repconvar = "rep_ttt_asc_allow_key_respawn", parent = tttrslst}
       tttrslst:AddItem(checkbox4)
+
+      local checkbox5 = xlib.makecheckbox{label = "ttt_asc_use_kill_history (Def. 0)", repconvar = "rep_ttt_asc_use_kill_history", parent = tttrslst}
+      tttrslst:AddItem(checkbox5)
 
       xgui.hookEvent('onProcessModules', nil, tttrspnl.processModules)
   		xgui.addSubModule('Second Chance', tttrspnl, nil, name)

--- a/lua/terrortown/entities/items/item_ttt_asc/shared.lua
+++ b/lua/terrortown/entities/items/item_ttt_asc/shared.lua
@@ -20,12 +20,31 @@ if SERVER then
   function ITEM:Bought(ply)
     local chance = math.random(A_SECOND_CHANCE.CVARS.min_start_pct, A_SECOND_CHANCE.CVARS.max_start_pct)
 
+    if A_SECOND_CHANCE.CVARS.use_kill_history then
+      if ply.asc_right_kills then
+        for i = 1, ply.asc_right_kills do
+          chance = math.min(99, chance+math.random(A_SECOND_CHANCE.CVARS.min_gain_pct, A_SECOND_CHANCE.CVARS.max_gain_pct))
+        end
+      end
+
+      if ply.asc_wrong_kills then
+        for i = 1, ply.asc_wrong_kills do
+          chance = math.max(1, chance-math.random(A_SECOND_CHANCE.CVARS.min_lose_pct, A_SECOND_CHANCE.CVARS.max_lose_pct))
+        end
+      end
+    end
+
+    ply.asc_right_kills = nil
+    ply.asc_wrong_kills = nil
+
     ply:TTT2NETSetUInt("ttt_asc_chance", chance, 8)
     A_SECOND_CHANCE:ChanceChanged(ply)
   end
 
   function ITEM:Reset(ply)
     ply:TTT2NETSetUInt("ttt_asc_chance", 0, 8)
+    ply.asc_right_kills = nil
+    ply.asc_wrong_kills = nil
   end
 
 else

--- a/lua/terrortown/entities/items/item_ttt_asc/sv_init.lua
+++ b/lua/terrortown/entities/items/item_ttt_asc/sv_init.lua
@@ -65,6 +65,17 @@ function A_SECOND_CHANCE:HandleDeathAttacker(ply, attacker)
   A_SECOND_CHANCE:ChanceChanged(attacker)
 end
 
+function A_SECOND_CHANCE:HandleKillRecord(ply, attacker)
+  if not A_SECOND_CHANCE.CVARS.use_kill_history or not IsValid(attacker) or not attacker:IsPlayer() or ply == attacker or attacker:HasEquipmentItem("item_ttt_asc") or not attacker:IsTerror() or not ply:IsTerror() then return end
+
+  if attacker:IsInTeam(ply) then
+    attacker.asc_wrong_kills = attacker.asc_wrong_kills and attacker.asc_wrong_kills+1 or 1
+    return
+  end
+
+  attacker.asc_right_kills = attacker.asc_right_kills and attacker.asc_right_kills+1 or 1
+end
+
 function A_SECOND_CHANCE:HandleRespawn(ply, delay, needCorpse, respawnAtCorpse)
   local spawnEntity = nil
   local spawnPos = nil
@@ -96,12 +107,15 @@ end
 
 function A_SECOND_CHANCE:ResetPlayer(ply)
   ply:TTT2NETSetBool("ttt_asc_respawning_allowkey", false)
+  ply.asc_right_kills = nil
+  ply.asc_wrong_kills = nil
 end
 
 
 hook.Add("DoPlayerDeath", "TTT_ASC_HANDLE_DEATH", function(ply, attacker)
   A_SECOND_CHANCE:HandleDeathVictim(ply, attacker)
   A_SECOND_CHANCE:HandleDeathAttacker(ply, attacker)
+  A_SECOND_CHANCE:HandleKillRecord(ply, attacker)
 end)
 
 


### PR DESCRIPTION
Added a kill history. If you kill players before you buy ASC a history of right and wrong kills will be made. Once you buy the Item, all right and wrong kills will be accounted to the start percantage.
This is disabled by default.